### PR TITLE
Allow use of EventEmitter-based debugging traces through the "on" method

### DIFF
--- a/sqlite-async.js
+++ b/sqlite-async.js
@@ -53,6 +53,10 @@ class Database {
     });
   }
 
+  on(evt, cb) {
+    return this.db.on(evt, cb);
+  }
+  
   close(fn) {
     if (!this.db) {
       return Promise.reject(new Error('Database.close: database is not open'));


### PR DESCRIPTION
Some debugging capabilities can be unlocked by allowing the _on_ method to be, essentially, forwarded to instances of the sqlite3 database class. This does only that.